### PR TITLE
[#54] ci: github actions added for releasing into pypi autometically …

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,17 @@
+name: Publish to PyPI.org
+on:
+  release:
+    types: [published]
+jobs:
+  pypi-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - run: python3 -m pip install --upgrade build && python3 -m build
+      - name: Publish package
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
### Description

GitHub action is added to publish leeteasy into *pypi* when a release is created in the github.

Closes #54

### Type of change
- [x] CI/CD

### Checklist:

- [x] branch name follows the branch naming convention mentioned [here](https://github.com/sudiptob2/leet-easy/blob/main/docs/BRANCH-NAMING.md)
- [x] commit messages to follow the format mentioned in [contributing.md](https://github.com/sudiptob2/leet-easy/blob/main/docs/CONTRIBUTING.md)
- [x] I have tested my code using `bash .github/check.sh`
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
